### PR TITLE
Minor performance improvements

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,38 @@
+package triangle
+
+import (
+	"bytes"
+	"image"
+	_ "image/png"
+	"os"
+	"testing"
+)
+
+func BenchmarkDraw(b *testing.B) {
+	buf, err := os.ReadFile("./output//sample_0.png")
+	if err != nil {
+		b.Skipf("Failed opening test file: %v", err)
+	}
+	img, _, err := image.Decode(bytes.NewBuffer(buf))
+	if err != nil {
+		b.Skipf("Failed decoding image: %v", err)
+	}
+	p := Image{
+		Processor: Processor{
+			MaxPoints:       2500,
+			BlurRadius:      4,
+			SobelThreshold:  10,
+			PointsThreshold: 20,
+			StrokeWidth:     0,
+			Wireframe:       0,
+		},
+	}
+	var out image.Image
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _, err = p.Draw(img, out, func() {})
+		if err != nil {
+			b.Fatalf("Failed drawing triangle benchmark image: %v", err)
+		}
+	}
+}

--- a/bench_test.go
+++ b/bench_test.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"image"
 	_ "image/png"
-	"os"
+	"io/ioutil"
 	"testing"
 )
 
 func BenchmarkDraw(b *testing.B) {
-	buf, err := os.ReadFile("./output//sample_0.png")
+	buf, err := ioutil.ReadFile("./output/sample_0.png")
 	if err != nil {
 		b.Skipf("Failed opening test file: %v", err)
 	}

--- a/delaunay.go
+++ b/delaunay.go
@@ -147,8 +147,8 @@ func (d *Delaunay) Insert(points []Point) *Delaunay {
 		y = points[k].y
 
 		triangles := d.triangles
-		edges = nil
-		temps = nil
+		edges = edges[:0]
+		temps = temps[:0]
 
 		for i = 0; i < len(d.triangles); i++ {
 			t := triangles[i]

--- a/delaunay.go
+++ b/delaunay.go
@@ -39,12 +39,12 @@ func (n Node) isEq(p Node) bool {
 
 // Edge struct having as component the node list.
 type edge struct {
-	nodes []Node
+	nodes [2]Node
 }
 
 // newEdge creates a new edge.
-func newEdge(p0, p1 Node) []Node {
-	nodes := []Node{p0, p1}
+func newEdge(p0, p1 Node) [2]Node {
+	nodes := [...]Node{p0, p1}
 	return nodes
 }
 

--- a/sobel.go
+++ b/sobel.go
@@ -90,12 +90,12 @@ func SobelFilter(img *image.NRGBA, threshold float64) *image.NRGBA {
 }
 
 // getImageData groups pixels into a 2D array, each one containing the pixel's RGB value.
-func getImageData(img *image.NRGBA) [][]uint8 {
+func getImageData(img *image.NRGBA) [][4]uint8 {
 	dx, dy := img.Bounds().Max.X, img.Bounds().Max.Y
-	pixels := make([][]uint8, dx*dy*4)
+	pixels := make([][4]uint8, dx*dy*4)
 
 	for i := 0; i < len(pixels); i += 4 {
-		pixels[i/4] = []uint8{
+		pixels[i/4] = [...]uint8{
 			img.Pix[i],
 			img.Pix[i+1],
 			img.Pix[i+2],

--- a/sobel.go
+++ b/sobel.go
@@ -32,18 +32,16 @@ func SobelFilter(img *image.NRGBA, threshold float64) *image.NRGBA {
 	maxPixelOffset := dx*2 + len(kernelX) - 1
 
 	data := getImageData(img)
-	length := len(data) - maxPixelOffset
-	magnitudes := make([]int32, length)
+	length := len(data)*4 - maxPixelOffset
+	magnitudes := make([]uint8, length)
 
 	for i := 0; i < length; i++ {
 		// Sum each pixel with the kernel value
 		sumX, sumY = 0, 0
 		for x := 0; x < len(kernelX); x++ {
 			for y := 0; y < len(kernelY); y++ {
-				px := data[i+(dx*y)+x]
-				if len(px) > 0 {
-					r := px[0]
-					// We are using px[0] (i.e. R value) because the image is grayscale anyway
+				if idx := i + (dx * y) + x; idx < len(data) {
+					r := data[i+(dx*y)+x]
 					sumX += int32(r) * kernelX[y][x]
 					sumY += int32(r) * kernelY[y][x]
 				}
@@ -59,7 +57,7 @@ func SobelFilter(img *image.NRGBA, threshold float64) *image.NRGBA {
 
 		// Set magnitude to 0 if doesn't exceed threshold, else set to magnitude
 		if magnitude > threshold {
-			magnitudes[i] = int32(magnitude)
+			magnitudes[i] = uint8(magnitude)
 		} else {
 			magnitudes[i] = 0
 		}
@@ -74,7 +72,7 @@ func SobelFilter(img *image.NRGBA, threshold float64) *image.NRGBA {
 		if i%4 != 0 {
 			m := magnitudes[i/4]
 			if m != 0 {
-				edges[i-1] = m
+				edges[i-1] = int32(m)
 			}
 		}
 	}
@@ -89,18 +87,14 @@ func SobelFilter(img *image.NRGBA, threshold float64) *image.NRGBA {
 	return dst
 }
 
-// getImageData groups pixels into a 2D array, each one containing the pixel's RGB value.
-func getImageData(img *image.NRGBA) [][4]uint8 {
+// getImageData returns an array of pixel grayscale brightness values
+// for the image (taking the red component of each pixel).
+func getImageData(img *image.NRGBA) []uint8 {
 	dx, dy := img.Bounds().Max.X, img.Bounds().Max.Y
-	pixels := make([][4]uint8, dx*dy*4)
+	pixels := make([]uint8, dx*dy)
 
-	for i := 0; i < len(pixels); i += 4 {
-		pixels[i/4] = [...]uint8{
-			img.Pix[i],
-			img.Pix[i+1],
-			img.Pix[i+2],
-			img.Pix[i+3],
-		}
+	for i := range pixels {
+		pixels[i] = img.Pix[i*4]
 	}
 	return pixels
 }


### PR DESCRIPTION
Hello! Thanks so much for this amazing library. It's been really fun to play with over the last day or so.

This PR is a series of tweaks I made to boost performance. These were guided by `pprof` and the included benchmark, but only tested on a single x86_64 Linux machine. They may not be an improvement everywhere.

That being said, they appear to represent a 24% speedup on my test hardware without compromising the output in any way.

I have never worked with these algorithms before, and it is definitely possible that my work contains mistakes that compromise the algorithms under some edge case that I failed to consider or did not understand.

I also don't know enough about the algorithms to know if the parameters being benchmarked represent the normal use-case well enough. Perhaps the benchmark should be using different values?

I did all of this because I have a toy program that transforms my webcam output using this library, and I'm trying to boost the realtime processing capability of this library. Even with all of these enhancements applied, I can only get 15-20FPS for very low-res images.

Regardless, I hope these are a useful reference point for optimization, even if they ultimately aren't merged.