### PR TITLE
Export useful fields and functions

### DIFF
--- a/delaunay.go
+++ b/delaunay.go
@@ -1,9 +1,9 @@
 package triangle
 
+import "image"
+
 // Point defines a struct having as components the point X and Y coordinate position.
-type Point struct {
-	x, y int
-}
+type Point = image.Point
 
 // Node defines a struct having as components the node X and Y coordinate position.
 type Node struct {
@@ -143,8 +143,8 @@ func (d *Delaunay) Insert(points []Point) *Delaunay {
 	)
 
 	for k = 0; k < len(points); k++ {
-		x = points[k].x
-		y = points[k].y
+		x = points[k].X
+		y = points[k].Y
 
 		triangles := d.triangles
 		edges = edges[:0]

--- a/edges.go
+++ b/edges.go
@@ -45,7 +45,7 @@ func GetEdgePoints(img *image.NRGBA, threshold, maxPoints int) []Point {
 				sum /= total
 			}
 			if sum > threshold {
-				points = append(points, Point{x: x, y: y})
+				points = append(points, Point{X: x, Y: y})
 			}
 		}
 	}

--- a/process.go
+++ b/process.go
@@ -112,7 +112,7 @@ func (im *Image) Draw(input interface{}, output interface{}, fn func()) (image.I
 	ctx.Fill()
 
 	delaunay := &Delaunay{}
-	img := toNRGBA(src.(image.Image))
+	img := ToNRGBA(src.(image.Image))
 
 	blur := StackBlur(img, uint32(im.BlurRadius))
 	gray := Grayscale(blur)
@@ -246,7 +246,7 @@ func (svg *SVG) Draw(input io.Reader, output io.Writer, fn func()) (image.Image,
 	ctx.Fill()
 
 	delaunay := &Delaunay{}
-	img := toNRGBA(src)
+	img := ToNRGBA(src)
 
 	blur := StackBlur(img, uint32(svg.BlurRadius))
 	gray := Grayscale(blur)
@@ -305,8 +305,8 @@ func (svg *SVG) Draw(input io.Reader, output io.Writer, fn func()) (image.Image,
 	return nil, triangles, points, err
 }
 
-// toNRGBA converts any image type to *image.NRGBA with min-point at (0, 0).
-func toNRGBA(img image.Image) *image.NRGBA {
+// ToNRGBA converts any image type to *image.NRGBA with min-point at (0, 0).
+func ToNRGBA(img image.Image) *image.NRGBA {
 	srcBounds := img.Bounds()
 	if srcBounds.Min.X == 0 && srcBounds.Min.Y == 0 {
 		if src0, ok := img.(*image.NRGBA); ok {


### PR DESCRIPTION
This PR simply replaces this package's Point type with the stdlib equivalent (which is structurally identical) and exports a useful image format conversion helper. Both of these changes make it easier to build custom image processing pipelines atop this package.