### PR TITLE
doc: update `brew install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ $ go install
 The library can be installed via Homebrew too or by downloading the binary file from the [releases](https://github.com/esimov/triangle/releases) folder.
 
 ```bash
-$ brew tap esimov/triangle
 $ brew install triangle
 ```
 


### PR DESCRIPTION
The formula was introduced in Homebrew/homebrew-core#37749 and it is pretty well maintained in the homebrew/core. Thus updating the doc to use the core version. :)